### PR TITLE
chore: Add setup-node registry-url parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   node-check-latest:
     description: 'Whether to check for the latest Node.js version'
     required: false
+  node-registry:
+    description: 'The registry URL to use for Node.js package installation and publishing'
+    required: false
   setup-java:
     description: 'Whether to setup Java'
     required: false
@@ -145,6 +148,9 @@ outputs:
   node-version:
     description: 'The installed node version.'
     value: ${{ steps.setup-node.outputs.node-version }}
+  node-registry-url:
+    description: 'The registry URL used for package installation and publishing.'
+    value: ${{ inputs.node-registry || 'https://registry.npmjs.org/' }}
   python-version:
     description: "The installed Python or PyPy version. Useful when given a version range as input."
     value: ${{ steps.setup-python.outputs.python-version }}
@@ -256,6 +262,7 @@ runs:
         echo "Version: ${{ inputs.node-version }}"
         echo "Cache: ${{ inputs.node-cache }}"
         echo "Check Latest: ${{ inputs.node-check-latest }}"
+        echo "Registry URL: ${{ inputs.node-registry || 'https://registry.npmjs.org/' }}"
         echo "::endgroup::"
 
     - name: Setup NodeJS
@@ -266,6 +273,7 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.node-cache }}
         check-latest: ${{ inputs.node-check-latest == 'true' }}
+        registry-url: ${{ inputs.node-registry || 'https://registry.npmjs.org/' }}
 
     - name: Set Up Python Parameters
       id: setup-python-params


### PR DESCRIPTION
## Description

This pull request adds support for specifying a custom Node.js package registry URL in the GitHub Action by introducing a new input and output for the registry URL. It also updates the setup and logging steps to use this new input, defaulting to the public npm registry if not specified.

**Node.js registry configuration:**

* Added a new `node-registry` input to `action.yml` to allow users to specify a custom registry URL for Node.js package installation and publishing.
* Added a new `node-registry-url` output that reflects the registry URL used, defaulting to `https://registry.npmjs.org/` if not provided.
* Updated the logging step to display the registry URL being used.
* Updated the Node.js setup step to use the specified registry URL, falling back to the default if not provided.

## Related Issue(s)

Closes #14