### PR TITLE
feat: Update inputs for egress policy and additional checkout options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,6 @@ jobs:
           echo "::group::Verify Checkout Outputs"
             echo "Checkout Ref: ${{ steps.test-all.outputs.checkout-ref }}"
             echo "Checkout Commit: ${{ steps.test-all.outputs.checkout-commit }}"
-            echo "Checkout Path: ${{ steps.test-all.outputs.checkout-path }}"
           echo "::endgroup::"
           echo "::group::Verify Java Outputs"
             echo "Java Distribution: ${{ steps.test-all.outputs.java-distribution }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,13 @@ jobs:
         uses: ./
         id: test-all
         with:
+          egress-policy: audit
           checkout: true
           checkout-fetch-depth: 0
           checkout-ref: main
           checkout-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout-path: '.'
+          checkout-persist: true
           checkout-submodules: false
           setup-java: true
           java-distribution: 'temurin'
@@ -66,6 +69,7 @@ jobs:
           echo "::group::Verify Checkout Outputs"
             echo "Checkout Ref: ${{ steps.test-all.outputs.checkout-ref }}"
             echo "Checkout Commit: ${{ steps.test-all.outputs.checkout-commit }}"
+            echo "Checkout Path: ${{ steps.test-all.outputs.checkout-path }}"
           echo "::endgroup::"
           echo "::group::Verify Java Outputs"
             echo "Java Distribution: ${{ steps.test-all.outputs.java-distribution }}"
@@ -83,6 +87,7 @@ jobs:
           echo "::group::Verify Node.js Outputs"
             echo "Node.js Version: ${{ steps.test-all.outputs.node-version }}"
             echo "Node.js Cache Hit: ${{ steps.test-all.outputs.node-cache-hit }}"
+            echo "Node.js Registry URL: ${{ steps.test-all.outputs.node-registry-url }}"
             node -v
             npm -v
           echo "::endgroup::"
@@ -113,6 +118,25 @@ jobs:
           echo "::group::Verify Gomplate Installation"
             gomplate --version
           echo "::endgroup::"
+
+  test-egress-policy:
+    name: Test Egress Policy Input
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Action with Explicit Egress Policy
+        uses: ./
+        id: test-egress-policy
+        with:
+          egress-policy: audit
 
   test-checkout:
     name: Test Checkout Action

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Common steps for initializing a job for GitHub actions. This composite action co
 
 - `checkout-ref`: The branch, tag or SHA that was checked out
 - `checkout-commit`: The commit SHA that was checked out
-- `checkout-path`: The path that the repository was checked out into (relative to `$GITHUB_WORKSPACE`)
 
 **Java Outputs**
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Common steps for initializing a job for GitHub actions. This composite action co
 
 ## Features
 
-- Security hardening with Step Security's Harden Runner
+- Security hardening with Step Security's Harden Runner (configurable egress policy)
 - Repository checkout with configurable options
 - Multi-language support (Node.js, Java, Python, Go, Rust, Swift)
 - Build tool setup (Gradle, Task, gomplate)
@@ -25,15 +25,23 @@ Common steps for initializing a job for GitHub actions. This composite action co
 
 ### Inputs
 
+**Harden Runner**
+
+| Input         | Description                                  | Required | Default | Options           |
+|---------------|----------------------------------------------|----------|---------|-------------------|
+| egress-policy | Egress policy to apply to the runner         | No       | audit   | `audit`/`block`   |
+
 **Repository Checkout**
 
-| Input                | Description                                              | Required | Default | Options                    |
-|----------------------|----------------------------------------------------------|----------|---------|----------------------------|
-| checkout             | Whether to checkout the repository                       | No       | -       | `true`/`false`             |
-| checkout-ref         | The branch, tag or SHA to checkout                       | No       | -       | any `branch`/`tag`/`SHA`   |
-| checkout-token       | Personal access token (PAT) used to fetch the repository | No       | -       | `Token` used for checkout  |
-| checkout-fetch-depth | Depth of commit history to fetch                         | No       | 1       | `0` (full)/`1`/`2`/...     |
-| checkout-submodules  | Whether to fetch submodules                              | No       | false   | `true`/`false`/`recursive` |
+| Input                | Description                                                                  | Required | Default | Options                    |
+|----------------------|------------------------------------------------------------------------------|----------|---------|----------------------------|
+| checkout             | Whether to checkout the repository                                           | No       | -       | `true`/`false`             |
+| checkout-ref         | The branch, tag or SHA to checkout                                           | No       | -       | any `branch`/`tag`/`SHA`   |
+| checkout-token       | Personal access token (PAT) used to fetch the repository                     | No       | -       | `Token` used for checkout  |
+| checkout-path        | Path to checkout the repository into (relative to `${GITHUB_WORKSPACE}`)     | No       | `.`     | any relative path          |
+| checkout-fetch-depth | Depth of commit history to fetch                                             | No       | 1       | `0` (full)/`1`/`2`/...     |
+| checkout-persist     | Whether to configure the token with the local git config                     | No       | true    | `true`/`false`             |
+| checkout-submodules  | Whether to fetch submodules                                                  | No       | false   | `true`/`false`/`recursive` |
 
 **Java**
 
@@ -63,12 +71,13 @@ Common steps for initializing a job for GitHub actions. This composite action co
 
 **Node.js**
 
-| Input             | Description                                     | Required | Default |
-|-------------------|-------------------------------------------------|----------|---------|
-| setup-node        | Whether to setup Node.js                        | No       | -       |
-| node-version      | Node.js version to use                          | No       | -       |
-| node-cache        | Package manager for caching (npm, yarn, pnpm)   | No       | -       |
-| node-check-latest | Whether to check for the latest Node.js version | No       | -       |
+| Input             | Description                                                          | Required | Default                       |
+|-------------------|----------------------------------------------------------------------|----------|-------------------------------|
+| setup-node        | Whether to setup Node.js                                             | No       | -                             |
+| node-version      | Node.js version to use                                               | No       | -                             |
+| node-cache        | Package manager for caching (npm, yarn, pnpm)                        | No       | -                             |
+| node-check-latest | Whether to check for the latest Node.js version                      | No       | -                             |
+| node-registry     | Registry URL to use for Node.js package installation and publishing  | No       | `https://registry.npmjs.org/` |
 
 **Python**
 
@@ -118,8 +127,8 @@ Common steps for initializing a job for GitHub actions. This composite action co
 
 **Gomplate**
 
-| Input          | Description              | Required | Default |
-|----------------|--------------------------|----------|---------|
+| Input          | Description               | Required | Default |
+|----------------|---------------------------|----------|---------|
 | setup-gomplate | Whether to setup gomplate | No       | false   |
 
 > [!NOTE]
@@ -131,6 +140,7 @@ Common steps for initializing a job for GitHub actions. This composite action co
 
 - `checkout-ref`: The branch, tag or SHA that was checked out
 - `checkout-commit`: The commit SHA that was checked out
+- `checkout-path`: The path that the repository was checked out into (relative to `$GITHUB_WORKSPACE`)
 
 **Java Outputs**
 
@@ -146,8 +156,10 @@ Common steps for initializing a job for GitHub actions. This composite action co
 - `gradle-version`: Version of Gradle that was setup
 
 **Node.js Outputs**
+
 - `node-cache-hit`: Boolean indicating if cache was hit
 - `node-version`: The installed node version
+- `node-registry-url`: The registry URL used for package installation and publishing
 
 **Python Outputs**
 
@@ -219,6 +231,18 @@ Common steps for initializing a job for GitHub actions. This composite action co
     setup-python: 'true'
     python-version: '3.12'
     python-cache: 'pip'
+```
+
+**Blocking Egress Traffic**
+
+By default the Harden Runner step runs in `audit` mode. Set `egress-policy` to `block` to deny any
+network traffic that has not been explicitly allowed by the runner's policy.
+
+```yaml
+- uses: PandasWhoCode/initialize-github-job@v1
+  with:
+    egress-policy: 'block'
+    checkout: 'true'
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -160,9 +160,6 @@ outputs:
   checkout-commit:
     description: 'The commit SHA that was checked out'
     value: ${{ steps.checkout-code.outputs.commit }}
-  checkout-path:
-    description: 'The path that the repository was checked out into (relative to $GITHUB_WORKSPACE)'
-    value: ${{ steps.checkout-code.outputs.path }}
   java-distribution:
     description: 'Distribution of Java that has been installed'
     value: ${{ steps.setup-java.outputs.distribution }}

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,10 @@ description: 'Common steps for initializing a job for GitHub actions'
 author: 'PandasWhoCode'
 
 inputs:
+  egress-policy:
+    description: 'Egress policy to apply to the runner (audit or block)'
+    required: false
+    default: 'audit'
   checkout:
     description: 'Whether to checkout the repository'
     required: false
@@ -12,10 +16,18 @@ inputs:
   checkout-token:
     description: 'Personal access token (PAT) used to fetch the repository and set up task'
     required: false
+  checkout-path:
+    description: 'The path to checkout the repository into (relative to ${GITHUB_WORKSPACE})'
+    required: false
+    default: '.'
   checkout-fetch-depth:
     description: 'Depth of commit history to fetch'
     required: false
     default: '1'
+  checkout-persist:
+    description: 'Whether to configure the token with the local git config'
+    required: false
+    default: 'true'
   checkout-submodules:
     description: 'Whether to checkout submodules (true/false/recursive)'
     default: 'false'
@@ -148,6 +160,9 @@ outputs:
   checkout-commit:
     description: 'The commit SHA that was checked out'
     value: ${{ steps.checkout-code.outputs.commit }}
+  checkout-path:
+    description: 'The path that the repository was checked out into (relative to $GITHUB_WORKSPACE)'
+    value: ${{ steps.checkout-code.outputs.path }}
   java-distribution:
     description: 'Distribution of Java that has been installed'
     value: ${{ steps.setup-java.outputs.distribution }}
@@ -217,7 +232,7 @@ runs:
       id: harden-runner
       uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
       with:
-        egress-policy: audit
+        egress-policy: ${{ inputs.egress-policy }}
 
     - name: Checkout Code Parameters
       id: checkout-params
@@ -239,6 +254,8 @@ runs:
         submodules: ${{ inputs.checkout-submodules }}
         ref: ${{ inputs.checkout-ref }}
         token: ${{ inputs.checkout-token }}
+        path: ${{ inputs.checkout-path }}
+        persist-credentials: ${{ inputs.checkout-persist }}
 
     - name: Set Up Java Parameters
       id: setup-java-params


### PR DESCRIPTION
## Description

This pull request introduces several enhancements and new configuration options for the GitHub Actions workflow and composite action, focusing on improved security, flexibility in repository checkout, and better output reporting. The most significant changes are the addition of configurable egress policy for security hardening, expanded checkout options, and improved documentation and outputs for consumers of the action.

**Security and Egress Policy:**
- Added a configurable `egress-policy` input to the composite action and workflow, allowing users to set the Step Security Harden Runner to either `audit` (default) or `block` mode for network egress control. A new job was added to test this input, and documentation was updated to explain its usage. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R6-R9) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R39-R45) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R122-R140) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28-R43) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R247) [[7]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L220-R235)

**Repository Checkout Enhancements:**
- Introduced new inputs for checkout customization: `checkout-path` (specifies the directory to checkout into, defaulting to `.`) and `checkout-persist` (controls whether credentials are persisted, defaulting to `true`). These are now passed to the checkout step and documented. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R19-R30) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R257-R258) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R39-R45) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28-R43)

**Output Improvements:**
- Added new outputs: `checkout-path` (reports the checkout directory) and `node-registry-url` (reports the Node.js registry used). Workflow steps were updated to display these outputs for easier debugging and traceability. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R163-R165) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R72) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R90) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R143) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R159-R162)

**Documentation Updates:**
- Expanded the `README.md` to document the new inputs and outputs, including detailed tables and usage examples for egress policy, checkout options, and Node.js registry configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28-R43) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R80) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L122-R131) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R143) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R159-R162) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R247)

These changes provide improved security configurability, greater flexibility for repository checkout, and clearer outputs and documentation for users of the action.

## Related Issue(s)

- Closes #63 
- Closes #34