### PR TITLE
feat: Add setup-jq

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -510,11 +510,11 @@ jobs:
         uses: ./
         with:
           setup-jq: true
-          jq-version: 1.8.1
+          jq-version: 1.8.0
 
       - name: Verify JQ Version Matches Input
         env:
-          EXPECTED_VERSION: 1.8.1
+          EXPECTED_VERSION: 1.8.0
         run: |
           ACTUAL="$(jq --version)"
           ESCAPED_EXPECTED_VERSION="$(printf '%s\n' "${EXPECTED_VERSION}" | sed 's/[][(){}.^$*+?|\\]/\\&/g')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -523,34 +523,3 @@ jobs:
             echo "Expected jq version ${EXPECTED_VERSION}, got: ${ACTUAL}"
             exit 1
           fi
-
-  test-setup-jq-old-custom-version:
-    name: Test Setup JQ (legacy custom version)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        id: harden-runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Run Setup JQ Action (non-default version)
-        uses: ./
-        with:
-          setup-jq: true
-          jq-version: 1.7.1
-
-      - name: Verify JQ Version Matches Input
-        env:
-          EXPECTED_VERSION: 1.7
-        run: |
-          ACTUAL="$(jq --version)"
-          ESCAPED_EXPECTED_VERSION="$(printf '%s\n' "${EXPECTED_VERSION}" | sed 's/[][(){}.^$*+?|\\]/\\&/g')"
-          echo "jq reported: ${ACTUAL}"
-          if ! echo "${ACTUAL}" | grep -qE "(^jq-|[^0-9.])${ESCAPED_EXPECTED_VERSION}([^0-9.]|$)"; then
-            echo "Expected jq version ${EXPECTED_VERSION}, got: ${ACTUAL}"
-            exit 1
-          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -510,16 +510,47 @@ jobs:
         uses: ./
         with:
           setup-jq: true
-          jq-version: 1.7.0
+          jq-version: 1.8.0
 
       - name: Verify JQ Version Matches Input
         env:
-          EXPECTED_VERSION: 1.7.0
+          EXPECTED_VERSION: 1.8.0
         run: |
           ACTUAL="$(jq --version)"
           ESCAPED_EXPECTED_VERSION="$(printf '%s\n' "${EXPECTED_VERSION}" | sed 's/[][(){}.^$*+?|\\]/\\&/g')"
           echo "jq reported: ${ACTUAL}"
-          if ! echo "${ACTUAL}" | grep -qE "(^|[^0-9.])${ESCAPED_EXPECTED_VERSION}([^0-9.]|$)"; then
+          if ! echo "${ACTUAL}" | grep -qE "(^jq-|[^0-9.])${ESCAPED_EXPECTED_VERSION}([^0-9.]|$)"; then
+            echo "Expected jq version ${EXPECTED_VERSION}, got: ${ACTUAL}"
+            exit 1
+          fi
+
+  test-setup-jq-old-custom-version:
+    name: Test Setup JQ (legacy custom version)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Setup JQ Action (non-default version)
+        uses: ./
+        with:
+          setup-jq: true
+          jq-version: 1.7.1
+
+      - name: Verify JQ Version Matches Input
+        env:
+          EXPECTED_VERSION: 1.7
+        run: |
+          ACTUAL="$(jq --version)"
+          ESCAPED_EXPECTED_VERSION="$(printf '%s\n' "${EXPECTED_VERSION}" | sed 's/[][(){}.^$*+?|\\]/\\&/g')"
+          echo "jq reported: ${ACTUAL}"
+          if ! echo "${ACTUAL}" | grep -qE "(^jq-|[^0-9.])${ESCAPED_EXPECTED_VERSION}([^0-9.]|$)"; then
             echo "Expected jq version ${EXPECTED_VERSION}, got: ${ACTUAL}"
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
           task-version: '3.50.0'
           task-retries: '3'
           setup-gomplate: true
+          setup-jq: true
 
       - name: Verify Setup
         run: |
@@ -116,6 +117,12 @@ jobs:
           echo "::endgroup::"
           echo "::group::Verify Gomplate Installation"
             gomplate --version
+          echo "::endgroup::"
+          echo "::group::Verify Task Installation"
+            task --version
+          echo "::endgroup::"
+          echo "::group::Verify JQ Installation"
+            jq --version
           echo "::endgroup::"
 
   test-egress-policy:
@@ -461,5 +468,58 @@ jobs:
           echo "gomplate reported: ${ACTUAL}"
           if ! echo "${ACTUAL}" | grep -qE "(^|[^0-9.])${ESCAPED_EXPECTED_VERSION}([^0-9.]|$)"; then
             echo "Expected gomplate version ${EXPECTED_VERSION}, got: ${ACTUAL}"
+            exit 1
+          fi
+
+  test-setup-jq:
+    name: Test Setup JQ
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Setup JQ Action
+        uses: ./
+        with:
+          setup-jq: true
+
+      - name: Verify JQ Installation
+        run: |
+          jq --version
+
+  test-setup-jq-custom-version:
+    name: Test Setup JQ (custom version)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Setup JQ Action (non-default version)
+        uses: ./
+        with:
+          setup-jq: true
+          jq-version: 1.7.0
+
+      - name: Verify JQ Version Matches Input
+        env:
+          EXPECTED_VERSION: 1.7.0
+        run: |
+          ACTUAL="$(jq --version)"
+          ESCAPED_EXPECTED_VERSION="$(printf '%s\n' "${EXPECTED_VERSION}" | sed 's/[][(){}.^$*+?|\\]/\\&/g')"
+          echo "jq reported: ${ACTUAL}"
+          if ! echo "${ACTUAL}" | grep -qE "(^|[^0-9.])${ESCAPED_EXPECTED_VERSION}([^0-9.]|$)"; then
+            echo "Expected jq version ${EXPECTED_VERSION}, got: ${ACTUAL}"
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -510,11 +510,11 @@ jobs:
         uses: ./
         with:
           setup-jq: true
-          jq-version: 1.8.0
+          jq-version: 1.8.1
 
       - name: Verify JQ Version Matches Input
         env:
-          EXPECTED_VERSION: 1.8.0
+          EXPECTED_VERSION: 1.8.1
         run: |
           ACTUAL="$(jq --version)"
           ESCAPED_EXPECTED_VERSION="$(printf '%s\n' "${EXPECTED_VERSION}" | sed 's/[][(){}.^$*+?|\\]/\\&/g')"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Common steps for initializing a job for GitHub actions. This composite action co
 - Security hardening with Step Security's Harden Runner (configurable egress policy)
 - Repository checkout with configurable options
 - Multi-language support (Node.js, Java, Python, Go, Rust, Swift)
-- Build tool setup (Gradle, Task, gomplate)
+- Build tool setup (Gradle, Task, gomplate, jq)
 - Automatic caching for dependencies and build artifacts
 
 ## Usage
@@ -134,6 +134,18 @@ Common steps for initializing a job for GitHub actions. This composite action co
 
 > [!NOTE]
 > `setup-gomplate` currently installs the Linux AMD64 gomplate release artifact.
+
+**jq**
+
+| Input      | Description                       | Required | Default |
+|------------|-----------------------------------|----------|---------|
+| setup-jq   | Whether to setup jq               | No       | false   |
+| jq-version | Desired jq version (e.g. 1.7.1)   | No       | 1.7.1   |
+
+> [!NOTE]
+> `setup-jq` supports Linux (apt) and macOS (brew) runners. If the installed
+> version differs from `jq-version`, an upgrade is attempted via the system
+> package manager.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -140,12 +140,15 @@ Common steps for initializing a job for GitHub actions. This composite action co
 | Input      | Description                       | Required | Default |
 |------------|-----------------------------------|----------|---------|
 | setup-jq   | Whether to setup jq               | No       | false   |
-| jq-version | Desired jq version (e.g. 1.7.1)   | No       | 1.7.1   |
+| jq-version | Desired jq version (e.g. 1.8.1)   | No       | 1.8.1   |
 
 > [!NOTE]
-> `setup-jq` supports Linux (apt) and macOS (brew) runners. If the installed
-> version differs from `jq-version`, an upgrade is attempted via the system
-> package manager.
+> `setup-jq` downloads the requested jq release directly from
+> `github.com/jqlang/jq` (with sha256 verification) and installs it to
+> `/usr/local/bin/jq`. Supports Linux and macOS on `amd64`/`arm64`.
+> jq <1.8 truncates `jq --version` to `jq-X.Y` even on patch releases — the
+> binary itself is the exact requested version, but the reported version
+> string cannot distinguish 1.7.0 from 1.7.1.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -160,7 +160,7 @@ inputs:
     required: false
     default: 'false'
   jq-version:
-    description: 'Desired jq version (e.g. 1.7.1)'
+    description: 'Desired jq version (e.g. 1.8.1)'
     required: false
     default: '1.8.1'
 
@@ -491,6 +491,7 @@ runs:
       run: |
         echo "::group::Setting up jq"
         echo "Runner OS: ${RUNNER_OS}"
+        echo "Runner Arch: ${RUNNER_ARCH}"
         echo "Desired Version: ${JQ_VERSION}"
         echo "::endgroup::"
 
@@ -501,47 +502,39 @@ runs:
       env:
         JQ_VERSION: ${{ inputs.jq-version }}
       run: |
+        if [[ ! "${JQ_VERSION}" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+          echo "Invalid jq-version: '${JQ_VERSION}' (expected MAJOR.MINOR[.PATCH], e.g. 1.8.1)"
+          exit 1
+        fi
+
         case "${RUNNER_OS}" in
-          Linux)
-            if ! command -v jq >/dev/null 2>&1; then
-              echo "::group::Setup JQ Command"
-              sudo apt-get update
-              sudo apt-get install -y jq
-              echo "::endgroup::"
-            fi
-
-            # jq <1.8 truncates `jq --version` to `jq-X.Y` even for patch releases;
-            # 1.8+ reports the full `jq-X.Y.Z`. Accept either shape as a match.
-            JQ_INSTALLED="$(jq --version)"
-            JQ_WANT_MAJOR_MINOR="$(echo "${JQ_VERSION}" | cut -d. -f1,2)"
-            if [[ "${JQ_INSTALLED}" != "jq-${JQ_VERSION}" && "${JQ_INSTALLED}" != "jq-${JQ_WANT_MAJOR_MINOR}" ]]; then
-              echo "::group::Updating JQ Version"
-              sudo apt-get update
-              sudo apt-get install -y --only-upgrade jq
-              echo "::endgroup::"
-            fi
-            ;;
-          macOS)
-            if ! command -v jq >/dev/null 2>&1; then
-              echo "::group::Setup JQ Command"
-              brew install jq
-              echo "::endgroup::"
-            fi
-
-            JQ_INSTALLED="$(jq --version)"
-            JQ_WANT_MAJOR_MINOR="$(echo "${JQ_VERSION}" | cut -d. -f1,2)"
-            if [[ "${JQ_INSTALLED}" != "jq-${JQ_VERSION}" && "${JQ_INSTALLED}" != "jq-${JQ_WANT_MAJOR_MINOR}" ]]; then
-              echo "::group::Updating JQ Version"
-              brew update
-              brew upgrade jq
-              echo "::endgroup::"
-            fi
-            ;;
-          *)
-            echo "Unsupported runner OS for jq setup: ${RUNNER_OS}"
-            exit 1
-            ;;
+          Linux) JQ_OS="linux" ;;
+          macOS) JQ_OS="macos" ;;
+          *) echo "Unsupported runner OS for jq setup: ${RUNNER_OS}"; exit 1 ;;
         esac
+
+        case "${RUNNER_ARCH}" in
+          X64)   JQ_ARCH="amd64" ;;
+          ARM64) JQ_ARCH="arm64" ;;
+          *) echo "Unsupported runner arch for jq setup: ${RUNNER_ARCH}"; exit 1 ;;
+        esac
+
+        JQ_ASSET="jq-${JQ_OS}-${JQ_ARCH}"
+        JQ_RELEASE_URL="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}"
+
+        echo "::group::Download jq ${JQ_VERSION}"
+        curl -sSfL "${JQ_RELEASE_URL}/${JQ_ASSET}" \
+          -o /tmp/jq || { echo "Failed to download jq binary"; exit 1; }
+        curl -sSfL "${JQ_RELEASE_URL}/sha256sum.txt" \
+          -o /tmp/jq_checksums.txt || { echo "Failed to download jq checksums"; exit 1; }
+        EXPECTED_SHA="$(awk -v a="${JQ_ASSET}" '$2 == a { print $1 }' /tmp/jq_checksums.txt)"
+        if [ -z "${EXPECTED_SHA}" ]; then
+          echo "Unable to find checksum for ${JQ_ASSET}"
+          exit 1
+        fi
+        echo "${EXPECTED_SHA}  /tmp/jq" | shasum -a 256 -c - || { echo "jq checksum verification failed"; exit 1; }
+        sudo install -m 755 /tmp/jq /usr/local/bin/jq
+        echo "::endgroup::"
 
         echo "::group::Show JQ Version"
         jq --version

--- a/action.yml
+++ b/action.yml
@@ -488,7 +488,7 @@ runs:
         echo "Desired Version: ${{ inputs.jq-version }}"
         echo "::endgroup::"
 
-    - name: Install JSON Tools
+    - name: Install JQ
       id: setup-jq
       if: ${{ inputs.setup-jq == 'true' }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -450,25 +450,29 @@ runs:
       id: setup-gomplate-params
       if: ${{ inputs.setup-gomplate == 'true' }}
       shell: bash
+      env:
+        GOMPLATE_VERSION: ${{ inputs.gomplate-version }}
       run: |
         echo "::group::Setting up gomplate"
-        echo "Version: ${{ inputs.gomplate-version }}"
+        echo "Version: ${GOMPLATE_VERSION}"
         echo "::endgroup::"
 
     - name: Install Gomplate
       id: setup-gomplate
       if: ${{ inputs.setup-gomplate == 'true' }}
       shell: bash
+      env:
+        GOMPLATE_VERSION: ${{ inputs.gomplate-version }}
       run: |
-        if [[ ! "${{ inputs.gomplate-version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "Invalid gomplate-version: '${{ inputs.gomplate-version }}' (expected format vMAJOR.MINOR.PATCH, e.g. v5.0.0)"
+        if [[ ! "${GOMPLATE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Invalid gomplate-version: '${GOMPLATE_VERSION}' (expected format vMAJOR.MINOR.PATCH, e.g. v5.0.0)"
           exit 1
         fi
-        GOMPLATE_RELEASE_URL="https://github.com/hairyhenderson/gomplate/releases/download/${{ inputs.gomplate-version }}"
+        GOMPLATE_RELEASE_URL="https://github.com/hairyhenderson/gomplate/releases/download/${GOMPLATE_VERSION}"
 
         curl -sSfL "${GOMPLATE_RELEASE_URL}/gomplate_linux-amd64" \
           -o /tmp/gomplate || { echo "Failed to download gomplate binary"; exit 1; }
-        curl -sSfL "${GOMPLATE_RELEASE_URL}/checksums-${{ inputs.gomplate-version }}_sha256.txt" \
+        curl -sSfL "${GOMPLATE_RELEASE_URL}/checksums-${GOMPLATE_VERSION}_sha256.txt" \
           -o /tmp/gomplate_checksums.txt || { echo "Failed to download gomplate checksums"; exit 1; }
         EXPECTED_SHA="$(grep 'bin/gomplate_linux-amd64$' /tmp/gomplate_checksums.txt | awk '{print $1}')"
         if [ -z "${EXPECTED_SHA}" ]; then
@@ -482,16 +486,20 @@ runs:
       id: setup-jq-params
       if: ${{ inputs.setup-jq == 'true' }}
       shell: bash
+      env:
+        JQ_VERSION: ${{ inputs.jq-version }}
       run: |
         echo "::group::Setting up jq"
         echo "Runner OS: ${RUNNER_OS}"
-        echo "Desired Version: ${{ inputs.jq-version }}"
+        echo "Desired Version: ${JQ_VERSION}"
         echo "::endgroup::"
 
     - name: Install JQ
       id: setup-jq
       if: ${{ inputs.setup-jq == 'true' }}
       shell: bash
+      env:
+        JQ_VERSION: ${{ inputs.jq-version }}
       run: |
         case "${RUNNER_OS}" in
           Linux)
@@ -505,18 +513,11 @@ runs:
             # jq <1.8 truncates `jq --version` to `jq-X.Y` even for patch releases;
             # 1.8+ reports the full `jq-X.Y.Z`. Accept either shape as a match.
             JQ_INSTALLED="$(jq --version)"
-            JQ_WANT_MAJOR_MINOR="$(echo "${{ inputs.jq-version }}" | cut -d. -f1,2)"
-            if [[ "${JQ_INSTALLED}" != "jq-${{ inputs.jq-version }}" && "${JQ_INSTALLED}" != "jq-${JQ_WANT_MAJOR_MINOR}" ]]; then
+            JQ_WANT_MAJOR_MINOR="$(echo "${JQ_VERSION}" | cut -d. -f1,2)"
+            if [[ "${JQ_INSTALLED}" != "jq-${JQ_VERSION}" && "${JQ_INSTALLED}" != "jq-${JQ_WANT_MAJOR_MINOR}" ]]; then
               echo "::group::Updating JQ Version"
               sudo apt-get update
               sudo apt-get install -y --only-upgrade jq
-              echo "::endgroup::"
-            fi
-
-            if ! command -v tee >/dev/null 2>&1; then
-              echo "::group::Setup Tee Command"
-              sudo apt-get update
-              sudo apt-get install -y coreutils
               echo "::endgroup::"
             fi
             ;;
@@ -528,17 +529,11 @@ runs:
             fi
 
             JQ_INSTALLED="$(jq --version)"
-            JQ_WANT_MAJOR_MINOR="$(echo "${{ inputs.jq-version }}" | cut -d. -f1,2)"
-            if [[ "${JQ_INSTALLED}" != "jq-${{ inputs.jq-version }}" && "${JQ_INSTALLED}" != "jq-${JQ_WANT_MAJOR_MINOR}" ]]; then
+            JQ_WANT_MAJOR_MINOR="$(echo "${JQ_VERSION}" | cut -d. -f1,2)"
+            if [[ "${JQ_INSTALLED}" != "jq-${JQ_VERSION}" && "${JQ_INSTALLED}" != "jq-${JQ_WANT_MAJOR_MINOR}" ]]; then
               echo "::group::Updating JQ Version"
               brew update
               brew upgrade jq
-              echo "::endgroup::"
-            fi
-
-            if ! command -v tee >/dev/null 2>&1; then
-              echo "::group::Setup Tee Command"
-              brew install coreutils
               echo "::endgroup::"
             fi
             ;;

--- a/action.yml
+++ b/action.yml
@@ -155,6 +155,14 @@ inputs:
     description: 'Number of retries for Task setup in case of failure, default is 3.'
     required: false
     default: '3'
+  setup-jq:
+    description: 'Whether to setup jq'
+    required: false
+    default: 'false'
+  jq-version:
+    description: 'Desired jq version (e.g. 1.7.1)'
+    required: false
+    default: '1.7.1'
 
 # expose outputs from the sub-actions
 outputs:
@@ -442,29 +450,25 @@ runs:
       id: setup-gomplate-params
       if: ${{ inputs.setup-gomplate == 'true' }}
       shell: bash
-      env:
-        GOMPLATE_VERSION: ${{ inputs.gomplate-version }}
       run: |
         echo "::group::Setting up gomplate"
-        echo "Version: ${GOMPLATE_VERSION}"
+        echo "Version: ${{ inputs.gomplate-version }}"
         echo "::endgroup::"
 
     - name: Install Gomplate
       id: setup-gomplate
       if: ${{ inputs.setup-gomplate == 'true' }}
       shell: bash
-      env:
-        GOMPLATE_VERSION: ${{ inputs.gomplate-version }}
       run: |
-        if [[ ! "${GOMPLATE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "Invalid gomplate-version: '${GOMPLATE_VERSION}' (expected format vMAJOR.MINOR.PATCH, e.g. v5.0.0)"
+        if [[ ! "${{ inputs.gomplate-version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Invalid gomplate-version: '${{ inputs.gomplate-version }}' (expected format vMAJOR.MINOR.PATCH, e.g. v5.0.0)"
           exit 1
         fi
-        GOMPLATE_RELEASE_URL="https://github.com/hairyhenderson/gomplate/releases/download/${GOMPLATE_VERSION}"
+        GOMPLATE_RELEASE_URL="https://github.com/hairyhenderson/gomplate/releases/download/${{ inputs.gomplate-version }}"
 
         curl -sSfL "${GOMPLATE_RELEASE_URL}/gomplate_linux-amd64" \
           -o /tmp/gomplate || { echo "Failed to download gomplate binary"; exit 1; }
-        curl -sSfL "${GOMPLATE_RELEASE_URL}/checksums-${GOMPLATE_VERSION}_sha256.txt" \
+        curl -sSfL "${GOMPLATE_RELEASE_URL}/checksums-${{ inputs.gomplate-version }}_sha256.txt" \
           -o /tmp/gomplate_checksums.txt || { echo "Failed to download gomplate checksums"; exit 1; }
         EXPECTED_SHA="$(grep 'bin/gomplate_linux-amd64$' /tmp/gomplate_checksums.txt | awk '{print $1}')"
         if [ -z "${EXPECTED_SHA}" ]; then
@@ -473,6 +477,74 @@ runs:
         fi
         echo "${EXPECTED_SHA}  /tmp/gomplate" | sha256sum -c - || { echo "Gomplate checksum verification failed"; exit 1; }
         sudo install -m 755 /tmp/gomplate /usr/local/bin/gomplate
+
+    - name: Set Up jq Parameters
+      id: setup-jq-params
+      if: ${{ inputs.setup-jq == 'true' }}
+      shell: bash
+      run: |
+        echo "::group::Setting up jq"
+        echo "Runner OS: ${RUNNER_OS}"
+        echo "Desired Version: ${{ inputs.jq-version }}"
+        echo "::endgroup::"
+
+    - name: Install JSON Tools
+      id: setup-jq
+      if: ${{ inputs.setup-jq == 'true' }}
+      shell: bash
+      run: |
+        case "${RUNNER_OS}" in
+          Linux)
+            if ! command -v jq >/dev/null 2>&1; then
+              echo "::group::Setup JQ Command"
+              sudo apt-get update
+              sudo apt-get install -y jq
+              echo "::endgroup::"
+            fi
+
+            if [[ "$(jq --version)" != "jq-${{ inputs.jq-version }}" ]]; then
+              echo "::group::Updating JQ Version"
+              sudo apt-get update
+              sudo apt-get install -y --only-upgrade jq
+              echo "::endgroup::"
+            fi
+
+            if ! command -v tee >/dev/null 2>&1; then
+              echo "::group::Setup Tee Command"
+              sudo apt-get update
+              sudo apt-get install -y coreutils
+              echo "::endgroup::"
+            fi
+            ;;
+          macOS)
+            if ! command -v jq >/dev/null 2>&1; then
+              echo "::group::Setup JQ Command"
+              brew install jq
+              echo "::endgroup::"
+            fi
+
+            if [[ "$(jq --version)" != "jq-${{ inputs.jq-version }}" ]]; then
+              echo "::group::Updating JQ Version"
+              brew update
+              brew upgrade jq
+              echo "::endgroup::"
+            fi
+
+            if ! command -v tee >/dev/null 2>&1; then
+              echo "::group::Setup Tee Command"
+              brew install coreutils
+              echo "::endgroup::"
+            fi
+            ;;
+          *)
+            echo "Unsupported runner OS for jq setup: ${RUNNER_OS}"
+            exit 1
+            ;;
+        esac
+
+        echo "::group::Show JQ Version"
+        jq --version
+        echo "::endgroup::"
 
 branding:
   icon: 'arrow-up-right'

--- a/action.yml
+++ b/action.yml
@@ -162,7 +162,7 @@ inputs:
   jq-version:
     description: 'Desired jq version (e.g. 1.7.1)'
     required: false
-    default: '1.7.1'
+    default: '1.8.1'
 
 # expose outputs from the sub-actions
 outputs:
@@ -502,7 +502,11 @@ runs:
               echo "::endgroup::"
             fi
 
-            if [[ "$(jq --version)" != "jq-${{ inputs.jq-version }}" ]]; then
+            # jq <1.8 truncates `jq --version` to `jq-X.Y` even for patch releases;
+            # 1.8+ reports the full `jq-X.Y.Z`. Accept either shape as a match.
+            JQ_INSTALLED="$(jq --version)"
+            JQ_WANT_MAJOR_MINOR="$(echo "${{ inputs.jq-version }}" | cut -d. -f1,2)"
+            if [[ "${JQ_INSTALLED}" != "jq-${{ inputs.jq-version }}" && "${JQ_INSTALLED}" != "jq-${JQ_WANT_MAJOR_MINOR}" ]]; then
               echo "::group::Updating JQ Version"
               sudo apt-get update
               sudo apt-get install -y --only-upgrade jq
@@ -523,7 +527,9 @@ runs:
               echo "::endgroup::"
             fi
 
-            if [[ "$(jq --version)" != "jq-${{ inputs.jq-version }}" ]]; then
+            JQ_INSTALLED="$(jq --version)"
+            JQ_WANT_MAJOR_MINOR="$(echo "${{ inputs.jq-version }}" | cut -d. -f1,2)"
+            if [[ "${JQ_INSTALLED}" != "jq-${{ inputs.jq-version }}" && "${JQ_INSTALLED}" != "jq-${JQ_WANT_MAJOR_MINOR}" ]]; then
               echo "::group::Updating JQ Version"
               brew update
               brew upgrade jq


### PR DESCRIPTION
## Description

This pull request adds support for installing and configuring the `jq` command-line tool in the GitHub Actions workflow. It introduces new inputs to control `jq` installation and version, updates documentation, and adds tests to verify the setup. These changes make it easier to ensure a specific version of `jq` is available in CI jobs.

**New jq setup feature:**

* Added `setup-jq` and `jq-version` inputs to `action.yml`, allowing users to opt-in to installing `jq` and specify its version (defaulting to 1.8.1). The installation is supported on Linux and macOS for `amd64` and `arm64`, with SHA256 verification. (`action.yml` [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R158-R165) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R485-R542)
* Implemented logic in the composite action to download, verify, and install the requested `jq` version. (`action.yml` [action.ymlR485-R542](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R485-R542))

**Documentation updates:**

* Updated `README.md` to document the new `jq` setup options, including usage notes and a table describing the new inputs. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R138-R152)

**Workflow and test improvements:**

* Modified `.github/workflows/test.yml` to support `setup-jq` in the main test job and added two new jobs: one to test default `jq` setup and another to test installing a custom `jq` version. (`.github/workflows/test.yml` [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R66) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R473-R525)
* Enhanced the workflow verification steps to confirm that `jq` is installed and reports the expected version. (`.github/workflows/test.yml` [.github/workflows/test.ymlR121-R126](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R121-R126))

These changes provide robust, configurable support for `jq` in CI pipelines, improving developer experience and build reproducibility.

## Related Issue(s)

- Closes #68 