### PR TITLE
feat: Add setup semver option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
           task-retries: '3'
           setup-gomplate: true
           setup-jq: true
+          setup-semver: true
 
       - name: Verify Setup
         run: |
@@ -123,6 +124,9 @@ jobs:
           echo "::endgroup::"
           echo "::group::Verify JQ Installation"
             jq --version
+          echo "::endgroup::"
+          echo "::group::Verify SemVer Installation"
+            semver --version
           echo "::endgroup::"
 
   test-egress-policy:
@@ -521,5 +525,35 @@ jobs:
           echo "jq reported: ${ACTUAL}"
           if ! echo "${ACTUAL}" | grep -qE "(^jq-|[^0-9.])${ESCAPED_EXPECTED_VERSION}([^0-9.]|$)"; then
             echo "Expected jq version ${EXPECTED_VERSION}, got: ${ACTUAL}"
+            exit 1
+          fi
+
+  test-setup-semver:
+    name: Test Setup SemVer Tools
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run Setup Semver
+        id: test-setup-semver
+        uses: ./
+        with:
+          setup-semver: true
+
+      - name: Verify SemVer Installation
+        run: |
+          INSTALLED_VERSION="$(semver --version)"
+          OUTPUT_VERSION="${{ steps.test-setup-semver.outputs.semver-version }}"
+          echo "semver reported: ${INSTALLED_VERSION}"
+          echo "semver output: ${OUTPUT_VERSION}"
+          if [[ "${INSTALLED_VERSION}" != "${OUTPUT_VERSION}" ]]; then
+            echo "Expected semver version ${OUTPUT_VERSION}, got: ${INSTALLED_VERSION}"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ Common steps for initializing a job for GitHub actions. This composite action co
 > binary itself is the exact requested version, but the reported version
 > string cannot distinguish 1.7.0 from 1.7.1.
 
+**SemVer**
+
+| Input        | Description                     | Required | Default |
+|--------------|---------------------------------|----------|---------|
+| setup-semver | Whether to setup semver         | No       | false   |
+
+> [!NOTE]
+> `setup-semver` downloads the latest semver release directly from
+> https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
+> and installs it to `/usr/local/bin/semver`.
+
 ### Outputs
 
 **Checkout Outputs**
@@ -197,6 +208,10 @@ Common steps for initializing a job for GitHub actions. This composite action co
 - `swift-version`: The actual Swift version that was configured
 - `swift-toolchain`: JSON formatted toolchain snapshot metadata
 - `swift-sdks`: JSON formatted SDK snapshots metadata
+
+**SemVer Outputs**
+
+- `semver-version`: The installed semver version
 
 ## Examples
 
@@ -246,6 +261,7 @@ Common steps for initializing a job for GitHub actions. This composite action co
     setup-python: 'true'
     python-version: '3.12'
     python-cache: 'pip'
+    setup-semver: 'true'
 ```
 
 **Blocking Egress Traffic**

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Common steps for initializing a job for GitHub actions. This composite action co
 | setup-semver | Whether to setup semver         | No       | false   |
 
 > [!NOTE]
-> `setup-semver` downloads the latest semver release directly from
+> `setup-semver` downloads the semver script directly from
 > https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
 > and installs it to `/usr/local/bin/semver`.
 

--- a/action.yml
+++ b/action.yml
@@ -164,7 +164,7 @@ inputs:
     required: false
     default: '1.8.1'
   setup-semver:
-    description: 'Whether to setup semver tools'
+    description: 'Whether to setup semver tool'
     required: false
     default: 'false'
 
@@ -553,15 +553,16 @@ runs:
       shell: bash
       run: |
         echo "::group::Download SemVer Binary"
-        sudo curl -L -o /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
+        sudo curl -sSfL https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver \
+          -o /tmp/semver || { echo "Failed to download semver binary"; exit 1; }
         echo "::endgroup::"
         
         echo "::group::Change SemVer Binary Permissions"
-        sudo chmod -v +x /usr/local/bin/semver
+        sudo install -m 755 /tmp/semver /usr/local/bin/semver
         echo "::endgroup::"
         
         echo "::group::Show SemVer Binary Version Info"
-        VERSION=$(semver --version)
+        VERSION="$(/usr/local/bin/semver --version | tr -d '\n')"
         echo "semver version: ${VERSION}"
         echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
         echo "::endgroup::"

--- a/action.yml
+++ b/action.yml
@@ -163,6 +163,10 @@ inputs:
     description: 'Desired jq version (e.g. 1.8.1)'
     required: false
     default: '1.8.1'
+  setup-semver:
+    description: 'Whether to setup semver tools'
+    required: false
+    default: 'false'
 
 # expose outputs from the sub-actions
 outputs:
@@ -232,6 +236,9 @@ outputs:
   swift-sdks:
     description: 'JSON formatted SDK snapshots metadata that were configured.'
     value: ${{ steps.setup-swift.outputs.sdks }}
+  semver-version:
+    description: 'The installed semver version.'
+    value: ${{ steps.setup-semver.outputs.version }}
 
 runs:
   using: 'composite'
@@ -538,6 +545,25 @@ runs:
 
         echo "::group::Show JQ Version"
         jq --version
+        echo "::endgroup::"
+
+    - name: Setup Semver
+      id: setup-semver
+      if: ${{ inputs.setup-semver == 'true' }}
+      shell: bash
+      run: |
+        echo "::group::Download SemVer Binary"
+        sudo curl -L -o /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
+        echo "::endgroup::"
+        
+        echo "::group::Change SemVer Binary Permissions"
+        sudo chmod -v +x /usr/local/bin/semver
+        echo "::endgroup::"
+        
+        echo "::group::Show SemVer Binary Version Info"
+        VERSION=$(semver --version)
+        echo "semver version: ${VERSION}"
+        echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
         echo "::endgroup::"
 
 branding:


### PR DESCRIPTION
## Description

This pull request adds support for installing and verifying the `semver` tool in the GitHub Actions workflow. It introduces a new input to control whether `semver` should be set up, updates documentation and outputs accordingly, and adds tests to ensure the tool is installed and working as expected.

**SemVer tool integration:**

* Added a new `setup-semver` input to `action.yml` and updated the documentation in `README.md` to allow users to opt-in to installing the `semver` tool as part of the workflow. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R166-R169) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R153-R163)
* Implemented a new step in `action.yml` that downloads, installs, and verifies the `semver` tool, and exposes its version as an output. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R550-R568) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R239-R241) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R212-R215)
* Updated workflow examples in `README.md` to show how to use the new `setup-semver` input.

**Workflow and test enhancements:**

* Modified `.github/workflows/test.yml` to include `setup-semver` in relevant jobs and verify the installation of `semver`. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R67) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R128-R130)
* Added a dedicated `test-setup-semver` job in `.github/workflows/test.yml` to ensure the setup and output of the `semver` tool works as intended.

## Related Issue(s)

Closes #76