### PR TITLE
feat: add setup-deterministic-zip with pinned, checksum-verified install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
           setup-gomplate: true
           setup-jq: true
           setup-semver: true
+          setup-deterministic-zip: true
 
       - name: Verify Setup
         run: |
@@ -127,6 +128,9 @@ jobs:
           echo "::endgroup::"
           echo "::group::Verify SemVer Installation"
             semver --version
+          echo "::endgroup::"
+          echo "::group::Verify deterministic-zip Installation"
+            deterministic-zip --version
           echo "::endgroup::"
 
   test-egress-policy:
@@ -587,3 +591,25 @@ jobs:
             echo "Expected semver version ${OUTPUT_VERSION}, got: ${INSTALLED_VERSION}"
             exit 1
           fi
+
+  test-setup-deterministic-zip:
+    name: Test Setup deterministic-zip
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run Setup deterministic-zip Action
+        uses: ./
+        with:
+          setup-deterministic-zip: true
+
+      - name: Verify deterministic-zip Installation
+        run: |
+          deterministic-zip --version

--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ Common steps for initializing a job for GitHub actions. This composite action co
 > https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
 > and installs it to `/usr/local/bin/semver`.
 
+**Deterministic Zip**
+
+| Input                   | Description                      | Required | Default |
+|-------------------------|----------------------------------|----------|---------|
+| setup-deterministic-zip | Whether to setup deterministic-zip | No     | false   |
+
+> [!NOTE]
+> `setup-deterministic-zip` installs [timo-reymann/deterministic-zip](https://github.com/timo-reymann/deterministic-zip)
+> `1.2.0` to `/usr/local/bin/deterministic-zip`. The release asset is verified against a
+> hard-coded per-platform SHA-256 (fail-closed) rather than the release's own `.sha256`
+> sidecar, so an upstream asset swap is rejected. Supports Linux/macOS on amd64/arm64.
+
 ### Outputs
 
 **Checkout Outputs**
@@ -264,6 +276,7 @@ Common steps for initializing a job for GitHub actions. This composite action co
     python-version: '3.12'
     python-cache: 'pip'
     setup-semver: 'true'
+    setup-deterministic-zip: 'true'
 ```
 
 **Blocking Egress Traffic**

--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ Common steps for initializing a job for GitHub actions. This composite action co
 | setup-deterministic-zip | Whether to setup deterministic-zip | No     | false   |
 
 > [!NOTE]
-> `setup-deterministic-zip` installs [timo-reymann/deterministic-zip](https://github.com/timo-reymann/deterministic-zip)
-> `1.2.0` to `/usr/local/bin/deterministic-zip`. The release asset is verified against a
-> hard-coded per-platform SHA-256 (fail-closed) rather than the release's own `.sha256`
-> sidecar, so an upstream asset swap is rejected. Supports Linux/macOS on amd64/arm64.
+> `setup-deterministic-zip` installs [timo-reymann/deterministic-zip](https://github.com/timo-reymann/deterministic-zip) `1.2.0`
+> to `/usr/local/bin/deterministic-zip`. The release asset is verified against a hard-coded
+> per-platform SHA-256 (fail-closed) rather than the release's own `.sha256` sidecar, so an
+> upstream asset swap is rejected. Supports Linux/macOS on `amd64`/`arm64`.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -178,6 +178,10 @@ inputs:
     description: 'Whether to setup semver tool'
     required: false
     default: 'false'
+  setup-deterministic-zip:
+    description: 'Whether to setup deterministic-zip'
+    required: false
+    default: 'false'
 
 # expose outputs from the sub-actions
 outputs:
@@ -593,6 +597,64 @@ runs:
         VERSION="$(/usr/local/bin/semver --version | tr -d '\n')"
         echo "semver version: ${VERSION}"
         echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+        echo "::endgroup::"
+
+    - name: Setup Deterministic Zip
+      id: setup-deterministic-zip
+      if: ${{ inputs.setup-deterministic-zip == 'true' }}
+      shell: bash
+      env:
+        # Pinned to timo-reymann/deterministic-zip 1.2.0 with a per-platform SHA-256.
+        # The release ships its own <asset>.sha256 sidecars, but those are NOT trusted here:
+        # a release-asset swap on the upstream repo would replace the sidecar alongside the
+        # binary. Hard-coding the expected digests makes any such tamper fail closed.
+        # To bump: change DZIP_VERSION and refresh every DZIP_SHA256_* below, e.g.
+        #   curl -sSL .../<version>/deterministic-zip_linux-amd64 | shasum -a 256
+        DZIP_VERSION: '1.2.0'
+        DZIP_SHA256_LINUX_AMD64: '56e9c2e28c9f535f100df1a94df122b62f4f2f66300abde2cf68d6a236ee5eaa'
+        DZIP_SHA256_LINUX_ARM64: 'fdb7a11ede185a6002c3d9f79489078ac12386297af2e4200e720fe12cc7f22e'
+        DZIP_SHA256_DARWIN_AMD64: 'ba34c4b871ac7a2bf38e51ad7310865badd7dd21d017efb6ed8eeb1c260bed38'
+        DZIP_SHA256_DARWIN_ARM64: '86677a58ceffc31419d5815f7e6fb7b096b78e20a9c73dbf28f999c4ad8bfc67'
+      run: |
+        case "${RUNNER_OS}" in
+          Linux) DZIP_OS="linux" ;;
+          macOS) DZIP_OS="darwin" ;;
+          *) echo "Unsupported runner OS for deterministic-zip setup: ${RUNNER_OS}"; exit 1 ;;
+        esac
+
+        case "${RUNNER_ARCH}" in
+          X64)   DZIP_ARCH="amd64" ;;
+          ARM64) DZIP_ARCH="arm64" ;;
+          *) echo "Unsupported runner arch for deterministic-zip setup: ${RUNNER_ARCH}"; exit 1 ;;
+        esac
+
+        case "${DZIP_OS}-${DZIP_ARCH}" in
+          linux-amd64)  EXPECTED_SHA="${DZIP_SHA256_LINUX_AMD64}" ;;
+          linux-arm64)  EXPECTED_SHA="${DZIP_SHA256_LINUX_ARM64}" ;;
+          darwin-amd64) EXPECTED_SHA="${DZIP_SHA256_DARWIN_AMD64}" ;;
+          darwin-arm64) EXPECTED_SHA="${DZIP_SHA256_DARWIN_ARM64}" ;;
+          *) echo "No pinned deterministic-zip checksum for ${DZIP_OS}-${DZIP_ARCH}"; exit 1 ;;
+        esac
+
+        DZIP_ASSET="deterministic-zip_${DZIP_OS}-${DZIP_ARCH}"
+        DZIP_URL="https://github.com/timo-reymann/deterministic-zip/releases/download/${DZIP_VERSION}/${DZIP_ASSET}"
+
+        echo "::group::Download deterministic-zip ${DZIP_VERSION}"
+        curl -sSfL "${DZIP_URL}" -o /tmp/deterministic-zip \
+          || { echo "Failed to download deterministic-zip binary"; exit 1; }
+        echo "::endgroup::"
+
+        echo "::group::Verify deterministic-zip Checksum"
+        echo "${EXPECTED_SHA}  /tmp/deterministic-zip" | shasum -a 256 -c - \
+          || { echo "deterministic-zip checksum verification failed"; exit 1; }
+        echo "::endgroup::"
+
+        echo "::group::Change deterministic-zip Binary Permissions"
+        sudo install -m 755 /tmp/deterministic-zip /usr/local/bin/deterministic-zip
+        echo "::endgroup::"
+
+        echo "::group::Show deterministic-zip Version Info"
+        deterministic-zip --version
         echo "::endgroup::"
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -609,7 +609,7 @@ runs:
         # a release-asset swap on the upstream repo would replace the sidecar alongside the
         # binary. Hard-coding the expected digests makes any such tamper fail closed.
         # To bump: change DZIP_VERSION and refresh every DZIP_SHA256_* below, e.g.
-        #   curl -sSL .../<version>/deterministic-zip_linux-amd64 | shasum -a 256
+        #   curl -sSL https://github.com/timo-reymann/deterministic-zip/releases/download/<version>/deterministic-zip_linux-amd64 | shasum -a 256
         DZIP_VERSION: '1.2.0'
         DZIP_SHA256_LINUX_AMD64: '56e9c2e28c9f535f100df1a94df122b62f4f2f66300abde2cf68d6a236ee5eaa'
         DZIP_SHA256_LINUX_ARM64: 'fdb7a11ede185a6002c3d9f79489078ac12386297af2e4200e720fe12cc7f22e'


### PR DESCRIPTION
## Summary

Adds an opt-in `setup-deterministic-zip` installer that fetches [`timo-reymann/deterministic-zip`](https://github.com/timo-reymann/deterministic-zip) at a **pinned version (1.2.0)** and verifies the release asset against a **hard-coded per-platform SHA-256** before installing it, **failing closed** on mismatch. It follows the same pattern as the existing pinned+checksummed `setup-jq`, `setup-gomplate`, and `setup-semver` steps.

## Why

Consumers currently install deterministic-zip inline with an unpinned, unverified pattern:

```yaml
sudo curl -L -o /usr/local/bin/deterministic-zip \
  https://github.com/timo-reymann/deterministic-zip/releases/download/1.2.0/deterministic-zip_linux-amd64
sudo chmod -v +x /usr/local/bin/deterministic-zip
deterministic-zip --version
```

A mutable release tag with no integrity check means an upstream asset swap silently executes attacker-controlled code in the release path. This mirrors the `semver` supply-chain issue fixed in #90 / v1.2.2; this change lets consumers drop the inline `curl | sudo install` and opt in with `setup-deterministic-zip: 'true'` instead.

## Design note

The release ships its own `<asset>.sha256` sidecars, but those are **not** trusted here — a release-asset swap would replace the sidecar alongside the binary. The expected digests are hard-coded (as `semver` does), so any tamper fails closed. Supports Linux/macOS on amd64/arm64; bump instructions are in the step's env comment.

## Verification

Digests baked in were reproduced from the 1.2.0 release assets, e.g. `deterministic-zip_linux-amd64` → `56e9c2e28c9f535f100df1a94df122b62f4f2f66300abde2cf68d6a236ee5eaa`. A one-byte tamper changes the digest and `shasum -a 256 -c -` exits non-zero, aborting the step before install.

README updated with the new input and a usage note.

---

_Supersedes #91 (which was opened from a fork). Same commit, GPG-signed._
